### PR TITLE
Construction API (without using /send)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Instructions for Building & Deploying to the image repository
+#    export COMMIT_SHA=$(git rev-parse HEAD)
+#    docker build --build-arg COMMIT_SHA=$COMMIT_SHA -t gcr.io/celo-testnet/rosetta-cusd:$COMMIT_SHA .
+#    docker push gcr.io/celo-testnet/rosetta-cusd:$COMMIT_SHA
+
+FROM golang:1.14.12-alpine as builder
+WORKDIR /app
+RUN apk add --no-cache make gcc musl-dev linux-headers git
+
+# Download dependencies & cache them in docker layer
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Build rosetta-cusd
+#  (this saves to redownload everything when go.mod/sum didn't change)
+COPY . .
+RUN go build --tags musl -o main .
+
+# Default argument set by --cusd.port
+EXPOSE 8081/tcp
+
+ENTRYPOINT ["./main"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Currently, the Construction API endpoints are not yet implemented.
 
 ## Running Rosetta cUSD
 
-Prerequisites: the core Rosetta RPC server must be running in the background, on the version/branch specified in `services/versions.go` under `RosettaCoreVersion` (currently: `master` commit `c749ba869cc8fd70f4719fa726e0efead033c60b`), as this module queries it in order to service the above endpoints.
+Prerequisites: the [core Rosetta RPC server](https://github.com/celo-org/rosetta) must be running in the background, on the version/branch specified in `services/versions.go` under `RosettaCoreVersion` (currently: `beta/construction` commit `040db59734bb`), as this module queries it in order to service the above endpoints. See the [README.md](https://github.com/celo-org/rosetta/blob/master/README.md) for instructions on how to run the core server.
 
 The main command is `go run main.go` with the following flags:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,28 @@ Flags:
       --cUSD.port uint      Listening port for cUSD http server (default: 8081)
 ```
 
+### Building and running from Docker image
+
+*Coming soon -- a rosetta-cusd image in our public repository, once we have tagged our first release.*
+
+To build an up-to-date docker image locally, run the following:
+
+```sh
+cd rosetta-cusd
+docker build -t gcr.io/celo-testnet/rosetta-cusd:$USER .
+```
+
+To run `rosetta-cusd`, first ensure that the rosetta core service is running. If it is running on `localhost`, you can use `"http://host.docker.internal"` as the `CORE_URL` below.
+
+```sh
+# Create and delete:
+docker run --rm -p 8081:8081 gcr.io/celo-testnet/rosetta-cusd:$USER --core.url CORE_URL --core.port CORE_PORT
+# OR name the container, can be restarted after stopping:
+docker run --name rosetta-cusd -p 8081:8081 gcr.io/celo-testnet/rosetta-cusd:$USER --core.url CORE_URL --core.port CORE_PORT
+```
+
+Note that this command will listen for rosetta-cusd requests on port `8081`.
+
 ## Running `rosetta-cli` checks
 
 Run the `rosetta-cli check:data` by running both the core and module servers and then using the appropriate CLI configuration file located in `test/rosetta-cli-conf/[NETWORK]`.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,7 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'us.gcr.io/$PROJECT_ID/rosetta-cusd:$COMMIT_SHA', '--build-arg', 'COMMIT_SHA=$COMMIT_SHA', '.' ]
+  waitFor: ["-"]
+images:
+- 'us.gcr.io/$PROJECT_ID/rosetta-cusd:$COMMIT_SHA'
+timeout: 2700s

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/celo-org/rosetta-cusd
 go 1.14
 
 require (
+	github.com/celo-org/kliento v0.2.0
 	github.com/celo-org/rosetta v0.7.7-0.20210112164533-38858e4f59f5
 	github.com/coinbase/rosetta-sdk-go v0.5.9
 	github.com/ethereum/go-ethereum v1.9.23

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/celo-org/kliento v0.2.0
-	github.com/celo-org/rosetta v0.7.7-0.20210112164533-38858e4f59f5
+	github.com/celo-org/rosetta v0.7.7-0.20210119175349-040db59734bb
 	github.com/coinbase/rosetta-sdk-go v0.5.9
 	github.com/ethereum/go-ethereum v1.9.23
 	github.com/segmentio/golines v0.0.0-20200306054842-869934f8da7b // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,10 @@ module github.com/celo-org/rosetta-cusd
 go 1.14
 
 require (
-	github.com/celo-org/rosetta v0.7.7-0.20210105143400-c749ba869cc8
+	github.com/celo-org/rosetta v0.7.7-0.20210112164533-38858e4f59f5
 	github.com/coinbase/rosetta-sdk-go v0.5.9
 	github.com/ethereum/go-ethereum v1.9.23
+	github.com/segmentio/golines v0.0.0-20200306054842-869934f8da7b // indirect
 )
 
 replace github.com/ethereum/go-ethereum => github.com/celo-org/celo-blockchain v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,7 @@ github.com/celo-org/kliento v0.1.2-0.20200608140637-c5afc8cf0f44 h1:OIwtA7H4/P/9
 github.com/celo-org/kliento v0.1.2-0.20200608140637-c5afc8cf0f44/go.mod h1:OrzUyeaXpAgTfhl0+wUG4Y+Tfn+wpL49t2/5S9z9zjQ=
 github.com/celo-org/kliento v0.2.0 h1:x2upUFg7OsYIp4uHkTjnN1sHxgf/U12iEAMVj5UuBP8=
 github.com/celo-org/kliento v0.2.0/go.mod h1:OrzUyeaXpAgTfhl0+wUG4Y+Tfn+wpL49t2/5S9z9zjQ=
+github.com/celo-org/rosetta v0.7.6 h1:tvahX16t9Wr5q84fgu+aHDIc9zodCAvX0LY1d1BTTC0=
 github.com/celo-org/rosetta v0.7.7-0.20201222104501-5308094bba5a h1:ZvK9i4YQqm+pE/0cziixrm982hfN1uFrF7Hg50pb1fw=
 github.com/celo-org/rosetta v0.7.7-0.20201222104501-5308094bba5a/go.mod h1:A9bH3XlEXHG5vUmxpQ3/VehIoj+3/PVtS9DAuRXXJqI=
 github.com/celo-org/rosetta v0.7.7-0.20210105143400-c749ba869cc8 h1:/rypL7E5x+9MjOxFS+z5RJ/MKOqpIfKxPHC9XhyFCGE=
@@ -77,6 +78,10 @@ github.com/celo-org/rosetta v0.7.7-0.20210112104407-a338b95772ab h1:XigViS/O8B0j
 github.com/celo-org/rosetta v0.7.7-0.20210112104407-a338b95772ab/go.mod h1:6efaI2uL+rYT/wVExjSmjT5sTNqcJmPidn0CWe0UK1U=
 github.com/celo-org/rosetta v0.7.7-0.20210112164533-38858e4f59f5 h1:kZIF9Yeleqi59xjXyJhHGRUUpb9b/3Oso+nfBfTnVhc=
 github.com/celo-org/rosetta v0.7.7-0.20210112164533-38858e4f59f5/go.mod h1:6efaI2uL+rYT/wVExjSmjT5sTNqcJmPidn0CWe0UK1U=
+github.com/celo-org/rosetta v0.7.7-0.20210119174829-b8c80d2bec5c h1:sQiQlxtmnoy6dSeHMbXMNH2ukrnbclCG0hzFxoQShmo=
+github.com/celo-org/rosetta v0.7.7-0.20210119174829-b8c80d2bec5c/go.mod h1:6efaI2uL+rYT/wVExjSmjT5sTNqcJmPidn0CWe0UK1U=
+github.com/celo-org/rosetta v0.7.7-0.20210119175349-040db59734bb h1:oASZkdUtQqAUl63HeMSK8DKT550IjnfafjYISPBFVtE=
+github.com/celo-org/rosetta v0.7.7-0.20210119175349-040db59734bb/go.mod h1:6efaI2uL+rYT/wVExjSmjT5sTNqcJmPidn0CWe0UK1U=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/celo-org/rosetta v0.7.7-0.20201222104501-5308094bba5a h1:ZvK9i4YQqm+p
 github.com/celo-org/rosetta v0.7.7-0.20201222104501-5308094bba5a/go.mod h1:A9bH3XlEXHG5vUmxpQ3/VehIoj+3/PVtS9DAuRXXJqI=
 github.com/celo-org/rosetta v0.7.7-0.20210105143400-c749ba869cc8 h1:/rypL7E5x+9MjOxFS+z5RJ/MKOqpIfKxPHC9XhyFCGE=
 github.com/celo-org/rosetta v0.7.7-0.20210105143400-c749ba869cc8/go.mod h1:A9bH3XlEXHG5vUmxpQ3/VehIoj+3/PVtS9DAuRXXJqI=
+github.com/celo-org/rosetta v0.7.7-0.20210112164533-38858e4f59f5 h1:kZIF9Yeleqi59xjXyJhHGRUUpb9b/3Oso+nfBfTnVhc=
+github.com/celo-org/rosetta v0.7.7-0.20210112164533-38858e4f59f5/go.mod h1:6efaI2uL+rYT/wVExjSmjT5sTNqcJmPidn0CWe0UK1U=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -86,6 +88,7 @@ github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod
 github.com/coinbase/rosetta-sdk-go v0.5.9 h1:CuGQE3HFmYwdEACJnuOtVI9cofqPsGvq6FdFIzaOPKI=
 github.com/coinbase/rosetta-sdk-go v0.5.9/go.mod h1:xd4wYUhV3LkY78SPH8BUhc88rXfn2jYgN9BfiSjbcvM=
 github.com/coinbase/rosetta-sdk-go v0.6.7 h1:v2fzv1cOVWB4A2QjIEcZpuh/CFwfLmX+Jd6qP3AZHN0=
+github.com/coinbase/rosetta-sdk-go v0.6.8 h1:DCWvfpzN9HkKux0eBZwN+9b7vstP4ij77zpyHtYy8dk=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/celo-org/rosetta v0.7.7-0.20201222104501-5308094bba5a h1:ZvK9i4YQqm+p
 github.com/celo-org/rosetta v0.7.7-0.20201222104501-5308094bba5a/go.mod h1:A9bH3XlEXHG5vUmxpQ3/VehIoj+3/PVtS9DAuRXXJqI=
 github.com/celo-org/rosetta v0.7.7-0.20210105143400-c749ba869cc8 h1:/rypL7E5x+9MjOxFS+z5RJ/MKOqpIfKxPHC9XhyFCGE=
 github.com/celo-org/rosetta v0.7.7-0.20210105143400-c749ba869cc8/go.mod h1:A9bH3XlEXHG5vUmxpQ3/VehIoj+3/PVtS9DAuRXXJqI=
+github.com/celo-org/rosetta v0.7.7-0.20210112104407-a338b95772ab h1:XigViS/O8B0j38BrfJr8gOAUTrFnMDNy5USd5Kzr4R4=
+github.com/celo-org/rosetta v0.7.7-0.20210112104407-a338b95772ab/go.mod h1:6efaI2uL+rYT/wVExjSmjT5sTNqcJmPidn0CWe0UK1U=
 github.com/celo-org/rosetta v0.7.7-0.20210112164533-38858e4f59f5 h1:kZIF9Yeleqi59xjXyJhHGRUUpb9b/3Oso+nfBfTnVhc=
 github.com/celo-org/rosetta v0.7.7-0.20210112164533-38858e4f59f5/go.mod h1:6efaI2uL+rYT/wVExjSmjT5sTNqcJmPidn0CWe0UK1U=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/celo-org/celo-bls-go v0.1.6 h1:S9hfmKp02Wbd6k3GkCwc/1uCeg68ZP6JZ7qFGH
 github.com/celo-org/celo-bls-go v0.1.6/go.mod h1:eXUCLXu5F1yfd3M+3VaUk5ZUXaA0sLK2rWdLC1Cfaqo=
 github.com/celo-org/kliento v0.1.2-0.20200608140637-c5afc8cf0f44 h1:OIwtA7H4/P/9nh6ZL4Q2vZ9VO8azMzo7X0jyKRNrs0c=
 github.com/celo-org/kliento v0.1.2-0.20200608140637-c5afc8cf0f44/go.mod h1:OrzUyeaXpAgTfhl0+wUG4Y+Tfn+wpL49t2/5S9z9zjQ=
+github.com/celo-org/kliento v0.2.0 h1:x2upUFg7OsYIp4uHkTjnN1sHxgf/U12iEAMVj5UuBP8=
+github.com/celo-org/kliento v0.2.0/go.mod h1:OrzUyeaXpAgTfhl0+wUG4Y+Tfn+wpL49t2/5S9z9zjQ=
 github.com/celo-org/rosetta v0.7.7-0.20201222104501-5308094bba5a h1:ZvK9i4YQqm+pE/0cziixrm982hfN1uFrF7Hg50pb1fw=
 github.com/celo-org/rosetta v0.7.7-0.20201222104501-5308094bba5a/go.mod h1:A9bH3XlEXHG5vUmxpQ3/VehIoj+3/PVtS9DAuRXXJqI=
 github.com/celo-org/rosetta v0.7.7-0.20210105143400-c749ba869cc8 h1:/rypL7E5x+9MjOxFS+z5RJ/MKOqpIfKxPHC9XhyFCGE=

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func main() {
 	// Make sure network options match underlying core service options
 	resp, _, err := client.NetworkAPI.NetworkList(context.Background(), &types.MetadataRequest{})
 	if err != nil {
+		log.Printf("Could not get NetworkList\n")
 		log.Fatal(err)
 	}
 
@@ -63,11 +64,19 @@ func main() {
 		nil,
 	)
 	if err != nil {
+		log.Printf("Could not initialize asserter\n")
 		log.Fatal(err)
 	}
 
-	router, err := services.CreateRouter(client, asserter)
+	stableToken, err := services.NewStableToken(resp.NetworkIdentifiers[0].Network)
 	if err != nil {
+		log.Printf("Could not initialize StableToken\n")
+		log.Fatal(err)
+	}
+
+	router, err := services.CreateRouter(client, asserter, stableToken)
+	if err != nil {
+		log.Printf("Could not initialize Router\n")
 		log.Fatal(err)
 	}
 	loggedRouter := server.LoggerMiddleware(router)

--- a/services/account_service.go
+++ b/services/account_service.go
@@ -49,7 +49,7 @@ func (s *AccountAPIService) AccountBalance(
 	rawParams := &airgap.CallParams{
 		TxArgs: airgap.TxArgs{
 			Method: balanceOfMethod,
-			Args: []interface{}{request.AccountIdentifier.Address},
+			Args:   []interface{}{request.AccountIdentifier.Address},
 		},
 	}
 	// Set blockNumber param if applicable; if this is nil, defaults to tip.

--- a/services/block_service.go
+++ b/services/block_service.go
@@ -82,7 +82,7 @@ func opsFromLog(
 		inGroup = true
 	}
 	processOp := func(address common.Address, opValue *big.Int, inGroup bool) {
-		op := newAtomicOp(address, *opIndex, opValue, status, opType, *relatedOps)
+		op := newAtomicOp(address, *opIndex, opValue, &status, opType, *relatedOps)
 		*operations = append(*operations, op)
 		*opIndex++
 		// Do not include standalone ops in a related group
@@ -201,27 +201,6 @@ func (s *BlockAPIService) Block(
 	blockResp.OtherTransactions = nil
 
 	return blockResp, nil
-}
-
-func newAtomicOp(
-	account common.Address,
-	opIndex int64,
-	value *big.Int,
-	opStatus types.OperationStatus,
-	opType string,
-	relatedOps []*types.OperationIdentifier,
-) *types.Operation {
-
-	accountId := rpc.NewAccountIdentifier(account, nil)
-	opId := rpc.NewOperationIdentifier(opIndex)
-	return &types.Operation{
-		OperationIdentifier: opId,
-		RelatedOperations:   relatedOps,
-		Type:                opType,
-		Status:              opStatus.Status,
-		Account:             &accountId,
-		Amount:              rpc.NewAmount(value, CeloDollar),
-	}
 }
 
 // endpoint: /block/transaction

--- a/services/block_service.go
+++ b/services/block_service.go
@@ -28,7 +28,7 @@ import (
 
 // Implements the server.BlockAPIServicer interface.
 type BlockAPIService struct {
-	client *client.APIClient
+	client      *client.APIClient
 	stableToken *StableToken
 }
 
@@ -37,7 +37,7 @@ func NewBlockAPIService(
 	stableToken *StableToken,
 ) *BlockAPIService {
 	return &BlockAPIService{
-		client: client,
+		client:      client,
 		stableToken: stableToken,
 	}
 }

--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -1,0 +1,121 @@
+// Copyright 2020 Celo Org
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/coinbase/rosetta-sdk-go/client"
+	"github.com/coinbase/rosetta-sdk-go/types"
+)
+
+// Implements the server.ConstructionAPIServicer interface.
+type ConstructionAPIService struct {
+	client *client.APIClient
+}
+
+func NewConstructionAPIService(
+	client *client.APIClient,
+) *ConstructionAPIService {
+	return &ConstructionAPIService{
+		client: client,
+	}
+}
+
+// endpoint: /construction/derive
+func (s *ConstructionAPIService) ConstructionDerive(
+	ctx context.Context,
+	request *types.ConstructionDeriveRequest,
+) (*types.ConstructionDeriveResponse, *types.Error) {
+	resp, clientErr, _ := s.client.ConstructionAPI.ConstructionDerive(ctx, request)
+	// TODO test: should work as is
+	return resp, clientErr
+
+}
+
+// endpoint: /construction/preprocess
+func (s *ConstructionAPIService) ConstructionPreprocess(
+	ctx context.Context,
+	request *types.ConstructionPreprocessRequest,
+) (*types.ConstructionPreprocessResponse, *types.Error) {
+	resp, _, _ := s.client.ConstructionAPI.ConstructionPreprocess(ctx, request)
+	// TODO implement cUSD logic
+	fmt.Printf("%v\n", resp)
+	return nil, ErrUnimplemented
+}
+
+// endpoint: /construction/metadata
+func (s *ConstructionAPIService) ConstructionMetadata(
+	ctx context.Context,
+	request *types.ConstructionMetadataRequest,
+) (*types.ConstructionMetadataResponse, *types.Error) {
+	resp, clientErr, _ := s.client.ConstructionAPI.ConstructionMetadata(ctx, request)
+	// TODO likely passthrough will work here, may need to prepare formatting of request
+	return resp, clientErr
+}
+
+// endpoint: /construction/payloads
+func (s *ConstructionAPIService) ConstructionPayloads(
+	ctx context.Context,
+	request *types.ConstructionPayloadsRequest,
+) (*types.ConstructionPayloadsResponse, *types.Error) {
+	resp, _, _ := s.client.ConstructionAPI.ConstructionPayloads(ctx, request)
+	// TODO implement cUSD logic
+	fmt.Printf("%v\n", resp)
+	return nil, ErrUnimplemented
+}
+
+// endpoint: /construction/parse
+func (s *ConstructionAPIService) ConstructionParse(
+	ctx context.Context,
+	request *types.ConstructionParseRequest,
+) (*types.ConstructionParseResponse, *types.Error) {
+	resp, _, _ := s.client.ConstructionAPI.ConstructionParse(ctx, request)
+	// TODO implement cUSD logic
+	fmt.Printf("%v\n", resp)
+	return nil, ErrUnimplemented
+}
+
+// endpoint: /construction/combine
+func (s *ConstructionAPIService) ConstructionCombine(
+	ctx context.Context,
+	request *types.ConstructionCombineRequest,
+) (*types.ConstructionCombineResponse, *types.Error) {
+	resp, _, _ := s.client.ConstructionAPI.ConstructionCombine(ctx, request)
+	// TODO likely passthrough will work here, may need to prepare formatting of request
+	fmt.Printf("%v\n", resp)
+	return nil, ErrUnimplemented
+}
+
+// endpoint: /construction/hash
+func (s *ConstructionAPIService) ConstructionHash(
+	ctx context.Context,
+	request *types.ConstructionHashRequest,
+) (*types.TransactionIdentifierResponse, *types.Error) {
+	resp, clientErr, _ := s.client.ConstructionAPI.ConstructionHash(ctx, request)
+	// TODO test: should work as is
+	return resp, clientErr
+}
+
+// endpoint: /construction/submit
+func (s *ConstructionAPIService) ConstructionSubmit(
+	ctx context.Context,
+	request *types.ConstructionSubmitRequest,
+) (*types.TransactionIdentifierResponse, *types.Error) {
+	resp, clientErr, _ := s.client.ConstructionAPI.ConstructionSubmit(ctx, request)
+	// TODO test: should work as is
+	return resp, clientErr
+}

--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -15,11 +15,16 @@
 package services
 
 import (
+	"math/big"
 	"context"
 	"fmt"
 
+	"github.com/celo-org/rosetta/airgap"
+	"github.com/celo-org/rosetta/analyzer"
 	"github.com/coinbase/rosetta-sdk-go/client"
+	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // Implements the server.ConstructionAPIServicer interface.
@@ -41,9 +46,76 @@ func (s *ConstructionAPIService) ConstructionDerive(
 	request *types.ConstructionDeriveRequest,
 ) (*types.ConstructionDeriveResponse, *types.Error) {
 	resp, clientErr, _ := s.client.ConstructionAPI.ConstructionDerive(ctx, request)
-	// TODO test: should work as is
+
 	return resp, clientErr
 
+}
+
+// TODO move into core, as part of parser interface refactor
+// for testing now
+func checksumAddress(address string) (*common.Address, bool) {
+	var addr common.Address
+	mcAddr, err := common.NewMixedcaseAddressFromString(address)
+	if err != nil {
+		return &addr, false
+	}
+	addr = mcAddr.Address()
+	return &addr, true
+}
+
+// transferParser creates a closure which when called will
+// match and parse a transfer in a specified currency
+func transferParser(opTransfer string, currency *types.Currency) (func (ops []*types.Operation) (*airgap.TxArgs, *types.Error)) {
+	return func (ops []*types.Operation) (*airgap.TxArgs, *types.Error) {
+		descriptions := &parser.Descriptions{
+			OperationDescriptions: []*parser.OperationDescription{
+				{
+					Type:    opTransfer,
+					Account: &parser.AccountDescription{Exists: true},
+					Amount: &parser.AmountDescription{
+						Exists:   true,
+						Sign:     parser.NegativeAmountSign,
+						Currency: currency,
+					},
+				},
+				{
+					Type:    opTransfer,
+					Account: &parser.AccountDescription{Exists: true},
+					Amount: &parser.AmountDescription{
+						Exists:   true,
+						Sign:     parser.PositiveAmountSign,
+						Currency: currency,
+					},
+				},
+			},
+			OppositeAmounts: [][]int{{0, 1}},
+			ErrUnmatched:    true,
+		}
+		matches, err := parser.MatchOperations(descriptions, ops)
+		if err != nil {
+			return nil, ErrUnclearIntent
+		}
+		fromOp, _ := matches[0].First()
+		fromAddr, ok := checksumAddress(fromOp.Account.Address)
+		if !ok {
+			return nil, ErrValidation
+		}
+		toOp, _ := matches[1].First()
+		toAddr, ok := checksumAddress(toOp.Account.Address)
+		if !ok {
+			return nil, ErrValidation
+		}
+	
+		var txArgs airgap.TxArgs
+		txArgs.From = *fromAddr
+		txArgs.To = toAddr
+		txArgs.Value, ok = new(big.Int).SetString(toOp.Amount.Value, 10)
+		if !ok {
+			return nil, ErrInternal
+		}
+
+		return &txArgs, nil
+	}
 }
 
 // endpoint: /construction/preprocess
@@ -51,10 +123,35 @@ func (s *ConstructionAPIService) ConstructionPreprocess(
 	ctx context.Context,
 	request *types.ConstructionPreprocessRequest,
 ) (*types.ConstructionPreprocessResponse, *types.Error) {
-	resp, _, _ := s.client.ConstructionAPI.ConstructionPreprocess(ctx, request)
-	// TODO implement cUSD logic
-	fmt.Printf("%v\n", resp)
-	return nil, ErrUnimplemented
+
+	// TODO --> have parseTransferOps use a more general, currency independent function (transferParser(currency) -> func transferParserOps)
+	parseCUSDTransfer := transferParser(OpTransfer, CeloDollar)
+	txArgs, rosettaErr := parseCUSDTransfer(request.Operations)
+
+	if rosettaErr != nil {
+		return nil, rosettaErr
+	}
+	// Prepare request for "send" transaction in core construction preprocess
+	sendReq := &types.ConstructionPreprocessRequest{
+		NetworkIdentifier: request.NetworkIdentifier,
+		Operations: []*types.Operation{
+			{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index: 0,
+				},
+				Type: analyzer.OpSend.String(),
+				// Ops were parsed successfully, so use from (ops[0]) identifier
+				Account: request.Operations[0].Account,
+				Metadata: map[string]interface{}{
+					"method": "StableToken.transfer",
+					"args": [2]string{txArgs.To.Hex(), txArgs.Value.String()},
+				},
+			},
+		},
+	}
+	resp, clientErr, _ := s.client.ConstructionAPI.ConstructionPreprocess(ctx, sendReq)
+
+	return resp, clientErr
 }
 
 // endpoint: /construction/metadata

--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -17,7 +17,9 @@ package services
 import (
 	"math/big"
 	"context"
+	"encoding/hex"
 	"fmt"
+	"reflect"
 
 	"github.com/celo-org/rosetta/airgap"
 	"github.com/celo-org/rosetta/analyzer"
@@ -25,6 +27,8 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/celo-org/kliento/contracts"
+	// "github.com/celo-org/kliento/registry"
 )
 
 // Implements the server.ConstructionAPIServicer interface.
@@ -160,7 +164,7 @@ func (s *ConstructionAPIService) ConstructionMetadata(
 	request *types.ConstructionMetadataRequest,
 ) (*types.ConstructionMetadataResponse, *types.Error) {
 	resp, clientErr, _ := s.client.ConstructionAPI.ConstructionMetadata(ctx, request)
-	// TODO likely passthrough will work here, may need to prepare formatting of request
+
 	return resp, clientErr
 }
 
@@ -169,10 +173,9 @@ func (s *ConstructionAPIService) ConstructionPayloads(
 	ctx context.Context,
 	request *types.ConstructionPayloadsRequest,
 ) (*types.ConstructionPayloadsResponse, *types.Error) {
-	resp, _, _ := s.client.ConstructionAPI.ConstructionPayloads(ctx, request)
-	// TODO implement cUSD logic
-	fmt.Printf("%v\n", resp)
-	return nil, ErrUnimplemented
+	resp, clientErr, _ := s.client.ConstructionAPI.ConstructionPayloads(ctx, request)
+
+	return resp, clientErr
 }
 
 // endpoint: /construction/parse
@@ -180,8 +183,132 @@ func (s *ConstructionAPIService) ConstructionParse(
 	ctx context.Context,
 	request *types.ConstructionParseRequest,
 ) (*types.ConstructionParseResponse, *types.Error) {
-	resp, _, _ := s.client.ConstructionAPI.ConstructionParse(ctx, request)
-	// TODO implement cUSD logic
+	resp, clientErr, _ := s.client.ConstructionAPI.ConstructionParse(ctx, request)
+	if clientErr != nil {
+		return nil, clientErr
+	}
+	// Match expected response
+	descriptions := &parser.Descriptions{
+		OperationDescriptions: []*parser.OperationDescription{
+			{
+				Type:    analyzer.OpSend.String(),
+				Account: &parser.AccountDescription{Exists: true},
+				Amount: &parser.AmountDescription{Exists: false},
+				Metadata: []*parser.MetadataDescription{
+					{Key: "contract_address", ValueKind: reflect.String},
+					{Key: "data", ValueKind: reflect.String},
+				},
+			},
+		},
+		ErrUnmatched:    true,
+	}
+	fmt.Printf("%+v\n", resp.Operations[0])
+	matches, err := parser.MatchOperations(descriptions, resp.Operations)
+	if err != nil {
+		return nil, ErrUnclearIntent
+	}
+	fmt.Printf("%+v\n", matches)
+
+	// TODO move to utils if this logic stays
+	// for now try to parse as long as it matches hard-coded stableToken addr.
+	var stableTokenAddr string
+	switch networkId := request.NetworkIdentifier.Network; networkId {
+	case MainnetId:
+		stableTokenAddr = StableTokenAddrMainnet
+	case TestnetId:
+		stableTokenAddr = StableTokenAddrTestnet
+	default:
+		logError(fmt.Sprintf("Unknown StableToken contract address for Network %s", request.NetworkIdentifier.Network))
+		return nil, ErrValidation
+	}
+
+	sendOp, _ := matches[0].First()
+	strAddr, ok := sendOp.Metadata["contract_address"].(string)
+
+	if !ok {
+		logError("unexpected 'contract_address' type; string conversion failed")
+		return nil, ErrValidation
+	}
+	// Confirm that this is a transaction sent to the StableToken contract
+	if strAddr != stableTokenAddr {
+		logError("'to' address does not match StableToken contract address")
+		return nil, ErrInternal
+	}
+
+	// Unclear if we can use this??
+	// stableToken, err := contracts.NewStableToken(common.HexToAddress(strAddr), nil)
+	// if err != nil {
+	// 	logError("initializing StableToken object failed")
+	// 	return nil, ErrInternal
+	// }
+	// fmt.Printf("Initialized stabletoken\n")
+	// fmt.Printf("%+v\n", stableToken)
+
+	// Process using the deserialize/serialize args of argbuilder/celo method?
+	// TODO --> data is produced through the ABI; perhaps find a way of including the ABI here?
+
+	// TODO could abstract all of this into a ParseStableTokenTransfer function
+
+	parsedABI, err := contracts.ParseStableTokenABI()
+	if err != nil {
+		logError("could not parse StableToken ABI")
+		return nil, ErrInternal
+	}
+	dataStr, ok := sendOp.Metadata["data"].(string)
+	if !ok {
+		logError("unexpected 'data' type; string conversion failed")
+		return nil, ErrValidation
+	}
+	dataBytes, err := hex.DecodeString(dataStr)
+	if err != nil {
+		logError("decoding data to hex bytes")
+		return nil, ErrValidation
+	}
+	method, err := parsedABI.MethodById(dataBytes)
+	if err != nil {
+		return nil, ErrInternal
+	}
+	// fmt.Printf("parsed method: %s\n", method)
+	// fmt.Printf("parsed method: %s\n", method.Name)
+	// fmt.Printf("parsed method: %s\n", method.RawName)
+	// fmt.Printf("parsed method: %v\n", method.Outputs)
+	// fmt.Printf("parsed method: %v\n", method.Inputs)
+
+	beepParsed := parsedABI.Methods["transfer"]
+	// fmt.Printf("parsed method: %s\n", beepParsed)
+	// fmt.Printf("parsed method: %s\n", beepParsed.Name)
+	// fmt.Printf("parsed method: %s\n", beepParsed.RawName)
+	// fmt.Printf("parsed method: %v\n", beepParsed.Outputs)
+	// fmt.Printf("parsed method: %v\n", beepParsed.Inputs)
+
+	fmt.Printf("beep?: %s", parsedABI.Methods["transfer"])
+	// TODO --> more robust check that this is the correct ID
+	if (parsedABI.Methods["transfer"].RawName == method.RawName) {
+		fmt.Printf("WEEEEEE we made it!!!\n")
+	}
+	// attempt to process "send" operation (with assumption that it is StableToken.transfer)
+	// failure at any point --> return ErrUnclearIntent
+
+	// metadata := map[string]interface{}{
+	// 	"contract_address": tx.To.Hex(),
+	// 	"data":             tx.Data,
+	// }
+
+	// ops := []*types.Operation{
+	// 	{
+	// 		Type: analyzer.OpSend.String(),
+	// 		OperationIdentifier: &types.OperationIdentifier{
+	// 			Index: 0,
+	// 		},
+	// 		Account: &types.AccountIdentifier{
+	// 			Address: tx.From.Hex(),
+	// 		},
+	// 		Metadata: metadata,
+	// 	},
+	// }
+
+
+
 	fmt.Printf("%v\n", resp)
 	return nil, ErrUnimplemented
 }

--- a/services/router.go
+++ b/services/router.go
@@ -26,6 +26,7 @@ import (
 func CreateRouter(
 	client *client.APIClient,
 	asserter *asserter.Asserter,
+	stableToken *StableToken,
 ) (http.Handler, error) {
 
 	// Proxy calls to /network from core rosetta
@@ -45,7 +46,7 @@ func CreateRouter(
 	accountAPIController := server.NewAccountAPIController(accountAPIService, asserter)
 
 	// Proxy calls to /construction/* from core rosetta + implement own options
-	constructionAPIService := NewConstructionAPIService(client)
+	constructionAPIService := NewConstructionAPIService(client, stableToken)
 	constructionAPIController := server.NewConstructionAPIController(constructionAPIService, asserter)
 
 	return server.NewRouter(

--- a/services/router.go
+++ b/services/router.go
@@ -34,7 +34,7 @@ func CreateRouter(
 	networkAPIController := server.NewNetworkAPIController(networkAPIService, asserter)
 
 	// Proxy calls to /account from core rosetta + implement own options
-	blockAPIService := NewBlockAPIService(client)
+	blockAPIService := NewBlockAPIService(client, stableToken)
 	blockAPIController := server.NewBlockAPIController(blockAPIService, asserter)
 
 	// Proxy calls to /mempool from core rosetta

--- a/services/router.go
+++ b/services/router.go
@@ -44,10 +44,15 @@ func CreateRouter(
 	accountAPIService := NewAccountAPIService(client)
 	accountAPIController := server.NewAccountAPIController(accountAPIService, asserter)
 
+	// Proxy calls to /construction/* from core rosetta + implement own options
+	constructionAPIService := NewConstructionAPIService(client)
+	constructionAPIController := server.NewConstructionAPIController(constructionAPIService, asserter)
+
 	return server.NewRouter(
 		networkAPIController,
 		blockAPIController,
 		mempoolAPIController,
 		accountAPIController,
+		constructionAPIController,
 	), nil
 }

--- a/services/types.go
+++ b/services/types.go
@@ -87,7 +87,7 @@ var (
 )
 
 type StableToken struct {
-	BlockThreshold int
+	BlockThreshold int64
 	Address        common.Address
 	ABI            *abi.ABI
 }

--- a/services/types.go
+++ b/services/types.go
@@ -28,6 +28,9 @@ const (
 	StableTokenRegisteredMainnet = 2962
 	TestnetId                    = "44787"
 	MainnetId                    = "42220"
+	// TODO improve with kliento wrapper for this; otherwise need more complex logic with contract upgrades
+	StableTokenAddrTestnet       = "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1"
+	StableTokenAddrMainnet       = "0x765de816845861e75a25fca122bb6898b8b1282a"
 
 	// Operations
 	OpTransfer = "transfer"

--- a/services/types.go
+++ b/services/types.go
@@ -26,8 +26,8 @@ const (
 	// Blocks before this do not have StableToken Contract
 	StableTokenRegisteredTestnet = 544
 	StableTokenRegisteredMainnet = 2962
-	TestnetId                   = "44787"
-	MainnetId                   = "42220"
+	TestnetId                    = "44787"
+	MainnetId                    = "42220"
 
 	// Operations
 	OpTransfer = "transfer"

--- a/services/types.go
+++ b/services/types.go
@@ -48,11 +48,14 @@ var (
 	ErrCeloClient    = rpc.ErrCeloClient
 	ErrUnimplemented = rpc.ErrUnimplemented
 	ErrInternal      = rpc.ErrInternal
+	ErrUnclearIntent = rpc.ErrUnclearIntent
 
 	AllErrors = []*types.Error{
 		ErrValidation,
 		ErrCeloClient,
 		ErrUnimplemented,
+		ErrInternal,
+		ErrUnclearIntent,
 	}
 
 	// Operations and statuses

--- a/services/types.go
+++ b/services/types.go
@@ -46,14 +46,12 @@ var (
 	ErrCeloClient    = rpc.ErrCeloClient
 	ErrUnimplemented = rpc.ErrUnimplemented
 	ErrInternal      = rpc.ErrInternal
-	ErrUnclearIntent = rpc.ErrUnclearIntent
 
 	AllErrors = []*types.Error{
 		ErrValidation,
 		ErrCeloClient,
 		ErrUnimplemented,
 		ErrInternal,
-		ErrUnclearIntent,
 	}
 
 	// Operations and statuses

--- a/services/types.go
+++ b/services/types.go
@@ -26,16 +26,6 @@ import (
 )
 
 const (
-	// Blocks before this do not have StableToken Contract
-	StableTokenRegisteredTestnet = 544
-	StableTokenRegisteredMainnet = 2962
-	TestnetId                    = "44787"
-	MainnetId                    = "42220"
-	// TODO improve with kliento wrapper for this; otherwise need more complex logic with contract upgrades
-	// nolint:gosec
-	StableTokenAddrTestnet = "0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1"
-	StableTokenAddrMainnet = "0x765de816845861e75a25fca122bb6898b8b1282a"
-
 	// Operations
 	OpTransfer = "transfer"
 	OpFee      = "fee"
@@ -100,13 +90,16 @@ func NewStableToken(networkId string) (*StableToken, error) {
 		logError("could not parse StableToken ABI")
 		return nil, err
 	}
+
 	switch networkId {
-	case MainnetId:
-		params.BlockThreshold = StableTokenRegisteredMainnet
-		params.Address = common.HexToAddress(StableTokenAddrMainnet)
-	case TestnetId:
-		params.BlockThreshold = StableTokenRegisteredTestnet
-		params.Address = common.HexToAddress(StableTokenAddrTestnet)
+	// Mainnet
+	case "42220":
+		params.BlockThreshold = 2962
+		params.Address = common.HexToAddress("0x765de816845861e75a25fca122bb6898b8b1282a")
+	// Testnet
+	case "44787":
+		params.BlockThreshold = 544
+		params.Address = common.HexToAddress("0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1")
 	default:
 		return nil, errors.New("unable to initialize StableToken")
 	}

--- a/services/types.go
+++ b/services/types.go
@@ -17,6 +17,7 @@ package services
 import (
 	"errors"
 	"log"
+	"math/big"
 
 	"github.com/celo-org/kliento/contracts"
 	"github.com/celo-org/rosetta/service/rpc"
@@ -76,6 +77,7 @@ var (
 	}
 )
 
+// Types and wrappers for types that are not specific to one service
 type StableToken struct {
 	BlockThreshold int64
 	Address        common.Address
@@ -104,6 +106,30 @@ func NewStableToken(networkId string) (*StableToken, error) {
 		return nil, errors.New("unable to initialize StableToken")
 	}
 	return &params, nil
+}
+
+func newAtomicOp(
+	account common.Address,
+	opIndex int64,
+	value *big.Int,
+	opStatus *types.OperationStatus,
+	opType string,
+	relatedOps []*types.OperationIdentifier,
+) *types.Operation {
+
+	accountId := rpc.NewAccountIdentifier(account, nil)
+	opId := rpc.NewOperationIdentifier(opIndex)
+	op := &types.Operation{
+		OperationIdentifier: opId,
+		RelatedOperations:   relatedOps,
+		Type:                opType,
+		Account:             &accountId,
+		Amount:              rpc.NewAmount(value, CeloDollar),
+	}
+	if opStatus != nil {
+		op.Status = opStatus.Status
+	}
+	return op
 }
 
 func logError(errMsg string) {

--- a/services/versions.go
+++ b/services/versions.go
@@ -16,7 +16,8 @@ package services
 
 const (
 	// TODO revisit: manage dependency upon RosettaCore server running alongside this
-	RosettaCoreVersion = "master@c749ba869cc8fd70f4719fa726e0efead033c60b"
+	RosettaCoreVersion = "eelanagaraj/construction-send"
+	// go get github.com/celo-org/rosetta@38858e4f59f5128ce6e3a552fe268d2c6beea55f
 )
 
 var (

--- a/services/versions.go
+++ b/services/versions.go
@@ -16,8 +16,7 @@ package services
 
 const (
 	// TODO revisit: manage dependency upon RosettaCore server running alongside this
-	RosettaCoreVersion = "eelanagaraj/construction-send"
-	// go get github.com/celo-org/rosetta@38858e4f59f5128ce6e3a552fe268d2c6beea55f
+	RosettaCoreVersion = "beta/construction"
 )
 
 var (

--- a/test/rosetta-cli-conf/testnet/celo.ros
+++ b/test/rosetta-cli-conf/testnet/celo.ros
@@ -1,0 +1,147 @@
+request_funds(1){
+  find_account{
+    currency = {"symbol":"cGLD", "decimals":18};
+    random_account = find_balance({
+      "minimum_balance":{
+        "value": "0",
+        "currency": {{currency}}
+      },
+      "create_limit":1
+    });
+  },
+
+  // Create a separate scenario to request funds so that
+  // the address we are using to request funds does not
+  // get rolled back if funds do not yet exist.
+  request{
+    loaded_account = find_balance({
+      "account_identifier": {{random_account.account_identifier}},
+      "minimum_balance":{
+        "value": "10000000000000000",
+        "currency": {{currency}}
+      }
+    });
+  }
+}
+
+create_account(1){
+  create{
+    network = {"network":"44787", "blockchain":"celo"};
+    key = generate_key({"curve_type": "secp256k1"});
+    account = derive({
+      "network_identifier": {{network}},
+      "public_key": {{key.public_key}}
+    });
+    save_account({
+      "account_identifier": {{account.account_identifier}},
+      "keypair": {{key}}
+    });
+  }
+}
+
+transfer(1){
+  transfer{
+    transfer.network = {"network":"44787", "blockchain":"celo"};
+    currency = {"symbol":"cGLD", "decimals":18};
+    min_balance = "10000000000000000";
+    sender = find_balance({
+      "minimum_balance":{
+        "value": {{min_balance}},
+            "currency": {{currency}}
+        }
+    });
+
+    // rough estimate of cap on transaction fee for transfer on Celo
+    max_fee = "50000000000000";
+    // set a lower cap so as to not drain prefunded account too quickly
+    // TODO: division not yet supported in DSL
+    transaction_cap = {{min_balance}} - {{max_fee}};
+
+    recipient_amount = random_number({"minimum": "1", "maximum": {{transaction_cap}}});
+    print_message({"recipient_amount":{{recipient_amount}}});
+
+    sender_amount = 0 - {{recipient_amount}};
+    recipient = find_balance({
+      "not_account_identifier":[{{sender.account_identifier}}],
+      "minimum_balance":{
+        "value": "0",
+        "currency": {{currency}}
+      },
+      "create_limit": 100,
+      "create_probability": 50
+    });    
+    transfer.confirmation_depth = "1";
+    transfer.operations = [
+      {
+        "operation_identifier":{"index":0},
+        "type":"transfer",
+        "account":{{sender.account_identifier}},
+        "amount":{
+          "value": {{sender_amount}},
+          "currency":{{currency}}
+        }
+      },
+      {
+        "operation_identifier":{"index":1},
+        "type":"transfer",
+        "account":{{recipient.account_identifier}},
+        "amount":{
+          "value":{{recipient_amount}},
+          "currency":{{currency}}
+        },
+        "related_operations": [
+          {
+            "index":0
+          }
+        ]
+      }
+  ];
+  }
+}
+
+return_funds(10){
+  // TODO: add suggested fee dry run to ensure account fully cleared
+  transfer{
+    transfer.network = {"network":"44787", "blockchain":"celo"};
+    currency = {"symbol":"cGLD", "decimals":18};
+    max_fee = "50000000000000";
+
+    prefunded_account = {"address": "0x03dDDE31C7d3Bd9C6d190185E04A340981586427"};
+
+    sender = find_balance({
+      "not_account_identifier":[{{prefunded_account}}],
+      "minimum_balance":{
+        "value": {{max_fee}},
+        "currency": {{currency}}
+      }
+    });
+
+    // Set the recipient_amount as some sender.balance-max_fee
+    available_amount = {{sender.balance.value}} - {{max_fee}};
+    print_message({"available_amount":{{available_amount}}});
+    sender_amount = 0 - {{available_amount}};
+
+    // Provide a static address as the recipient and construct operations
+    transfer.confirmation_depth = "1";
+    transfer.operations = [
+      {
+        "operation_identifier":{"index":0},
+        "type":"transfer",
+        "account":{{sender.account_identifier}},
+        "amount":{
+          "value":{{sender_amount}},
+          "currency":{{currency}}
+        }
+      },
+      {
+        "operation_identifier":{"index":1},
+        "type":"transfer",
+        "account":{{prefunded_account}},
+        "amount":{
+          "value":{{available_amount}},
+          "currency":{{currency}}
+        }
+      }
+    ];
+  }
+}

--- a/test/rosetta-cli-conf/testnet/celo.ros
+++ b/test/rosetta-cli-conf/testnet/celo.ros
@@ -1,6 +1,6 @@
 request_funds(1){
   find_account{
-    currency = {"symbol":"cGLD", "decimals":18};
+    currency = {"symbol":"cUSD", "decimals":18};
     random_account = find_balance({
       "minimum_balance":{
         "value": "0",
@@ -42,17 +42,18 @@ create_account(1){
 transfer(1){
   transfer{
     transfer.network = {"network":"44787", "blockchain":"celo"};
-    currency = {"symbol":"cGLD", "decimals":18};
+    currency = {"symbol":"cUSD", "decimals":18};
     min_balance = "10000000000000000";
     sender = find_balance({
+      "account_identifier": {"address": "0x03dDDE31C7d3Bd9C6d190185E04A340981586427"},
       "minimum_balance":{
         "value": {{min_balance}},
             "currency": {{currency}}
         }
     });
-
     // rough estimate of cap on transaction fee for transfer on Celo
-    max_fee = "50000000000000";
+    // note that this will be paid in cUSD, so roughly convert the GasFee --> cUSD
+    max_fee = "1500000000";
     // set a lower cap so as to not drain prefunded account too quickly
     // TODO: division not yet supported in DSL
     transaction_cap = {{min_balance}} - {{max_fee}};
@@ -96,52 +97,5 @@ transfer(1){
         ]
       }
   ];
-  }
-}
-
-return_funds(10){
-  // TODO: add suggested fee dry run to ensure account fully cleared
-  transfer{
-    transfer.network = {"network":"44787", "blockchain":"celo"};
-    currency = {"symbol":"cGLD", "decimals":18};
-    max_fee = "50000000000000";
-
-    prefunded_account = {"address": "0x03dDDE31C7d3Bd9C6d190185E04A340981586427"};
-
-    sender = find_balance({
-      "not_account_identifier":[{{prefunded_account}}],
-      "minimum_balance":{
-        "value": {{max_fee}},
-        "currency": {{currency}}
-      }
-    });
-
-    // Set the recipient_amount as some sender.balance-max_fee
-    available_amount = {{sender.balance.value}} - {{max_fee}};
-    print_message({"available_amount":{{available_amount}}});
-    sender_amount = 0 - {{available_amount}};
-
-    // Provide a static address as the recipient and construct operations
-    transfer.confirmation_depth = "1";
-    transfer.operations = [
-      {
-        "operation_identifier":{"index":0},
-        "type":"transfer",
-        "account":{{sender.account_identifier}},
-        "amount":{
-          "value":{{sender_amount}},
-          "currency":{{currency}}
-        }
-      },
-      {
-        "operation_identifier":{"index":1},
-        "type":"transfer",
-        "account":{{prefunded_account}},
-        "amount":{
-          "value":{{available_amount}},
-          "currency":{{currency}}
-        }
-      }
-    ];
   }
 }

--- a/test/rosetta-cli-conf/testnet/celo.ros
+++ b/test/rosetta-cli-conf/testnet/celo.ros
@@ -44,6 +44,7 @@ transfer(1){
     transfer.network = {"network":"44787", "blockchain":"celo"};
     currency = {"symbol":"cUSD", "decimals":18};
     min_balance = "10000000000000000";
+    // For now, ensure send is from an unlocked account with both CELO and cUSD funds
     sender = find_balance({
       "account_identifier": {"address": "0x03dDDE31C7d3Bd9C6d190185E04A340981586427"},
       "minimum_balance":{

--- a/test/rosetta-cli-conf/testnet/cli-config.json
+++ b/test/rosetta-cli-conf/testnet/cli-config.json
@@ -4,7 +4,7 @@
       "network": "44787"
     },
     "online_url": "http://localhost:8081",
-    "data_directory": "checks-datadir-testnet",
+    "data_directory": "checks-datadir-testnet-2",
     "http_timeout": 300,
     "max_retries": 5,
     "retry_elapsed_time": 0,
@@ -14,7 +14,37 @@
     "log_configuration": false,
     "compression_disabled": false,
     "memory_limit_disabled": false,
-    "construction": null,
+    "construction": {
+      "offline_url": "http://localhost:8080",
+      "max_offline_connections": 4,
+      "stale_depth": 30,
+      "broadcast_limit": 3,
+      "ignore_broadcast_failures": false,
+      "clear_broadcasts": false,
+      "broadcast_behind_tip": false,
+      "block_broadcast_limit": 5,
+      "rebroadcast_all": false,
+      "prefunded_accounts": [
+        {
+          "privkey": "b803642b3a58699b8442546ccbd5d5c0d5dba97b2b5b868a263fd0f4c0fd7bc5",
+          "account_identifier": {
+            "address": "0x03dDDE31C7d3Bd9C6d190185E04A340981586427"
+          },
+          "curve_type": "secp256k1",
+          "currency": {
+            "symbol": "cGLD",
+            "decimals": 18
+          }
+        }
+      ],
+      "constructor_dsl_file": "celo.ros",
+      "status_port": 9090,
+      "initial_balance_fetch_disabled": false,
+      "end_conditions": {
+        "create_account": 2,
+        "send": 2
+      }
+    },  
     "data": {
       "active_reconciliation_concurrency": 16,
       "inactive_reconciliation_concurrency": 4,

--- a/test/rosetta-cli-conf/testnet/cli-config.json
+++ b/test/rosetta-cli-conf/testnet/cli-config.json
@@ -15,7 +15,7 @@
     "compression_disabled": false,
     "memory_limit_disabled": false,
     "construction": {
-      "offline_url": "http://localhost:8080",
+      "offline_url": "http://localhost:8081",
       "max_offline_connections": 4,
       "stale_depth": 30,
       "broadcast_limit": 3,
@@ -32,7 +32,7 @@
           },
           "curve_type": "secp256k1",
           "currency": {
-            "symbol": "cGLD",
+            "symbol": "cUSD",
             "decimals": 18
           }
         }
@@ -41,8 +41,8 @@
       "status_port": 9090,
       "initial_balance_fetch_disabled": false,
       "end_conditions": {
-        "create_account": 2,
-        "send": 2
+        "create_account": 10,
+        "transfer": 10
       }
     },  
     "data": {

--- a/test/rosetta-cli-conf/testnet/cli-config.json
+++ b/test/rosetta-cli-conf/testnet/cli-config.json
@@ -4,7 +4,7 @@
       "network": "44787"
     },
     "online_url": "http://localhost:8081",
-    "data_directory": "checks-datadir-testnet-2",
+    "data_directory": "",
     "http_timeout": 300,
     "max_retries": 5,
     "retry_elapsed_time": 0,


### PR DESCRIPTION
Based on feedback received on whether to expose a `/send` endpoint within `core` (this is not the preferred route), I rewrote the Construction API to not rely on this but instead prepare transactions mostly within the `cusd` module itself using kliento for ABI parsing and using only currency agnostic endpoints in core (like `/hash`). This also includes Docker support, meaning that it's possible to run the `rosetta-cusd` as a (very basic) docker container. This may be something we have to adjust depending on how Coinbase runs these services internally.

## Testing
- Constructing cUSD transactions using the rosetta cli works, albeit defaults to CELO gas

## Future work
- implement sending transactions with gas currency other than CELO (for CELO and cUSD transactions)
- staking flows (need to be implemented natively within the core module instead of by exposing the `/send` endpoint)